### PR TITLE
Fixed traits bugging custom job trees

### DIFF
--- a/data/traits/barbarian/barbarian.lua
+++ b/data/traits/barbarian/barbarian.lua
@@ -25,21 +25,18 @@ function Barbarian:post_activate()
          local options = {}
          options.dont_drop_talisman = true
          options.skip_visual_effects = true
+         local job_comp = self._sv._entity:get_component('stonehearth:job')
          local able_to_be_footman = pcall(function()
-           self._sv._entity:get_component('stonehearth:job'):promote_to('stonehearth:jobs:footman', options)
+            job_comp:promote_to('stonehearth:jobs:footman', options)
          end)
          if not able_to_be_footman then
-           local able_to_be_archer = pcall(function()
-             self._sv._entity:get_component('stonehearth:job'):promote_to('stonehearth:jobs:archer', options)
-           end)
+            local able_to_be_archer = pcall(function()
+               job_comp:promote_to('stonehearth:jobs:archer', options)
+            end)
          end
-         local all_jobs = stonehearth.player:get_jobs(self._sv._entity:get_player_id())
-         local allowed_jobs = {}
-         for job_uri, _ in pairs(all_jobs) do
-            allowed_jobs[job_uri] = true
-         end
-         self._sv._entity:get_component('stonehearth:job')._sv.allowed_jobs = allowed_jobs
-         self._sv._entity:get_component('stonehearth:job')._sv.allowed_jobs["stonehearth:jobs:knight"] = false
+         local allowed = job_comp:get_allowed_jobs()
+         allowed["stonehearth:jobs:knight"] = false
+         job_comp:set_allowed_jobs(allowed)
          self._sv._entity:get_component('stonehearth:unit_info')._sv._made_barbarian = true
          self:don_outfit()
       end
@@ -71,7 +68,7 @@ if EquipmentPieceComponent and not EquipmentPieceComponent.kmnky_traits_injectio
       end
    end
 
-    EquipmentPieceComponent.kmnky_traits_injection2 = true
+   EquipmentPieceComponent.kmnky_traits_injection2 = true
 end
 
 return Barbarian

--- a/data/traits/pacifist/pacifist.lua
+++ b/data/traits/pacifist/pacifist.lua
@@ -1,59 +1,55 @@
 
 local Pacifist = class()
 
-local log = radiant.log.create_logger('kai')
+-- local log = radiant.log.create_logger('kai')
 function Pacifist:initialize()
-   self._sv._entity = nil
-   self._sv._uri = nil
+	self._sv._entity = nil
+	self._sv._uri = nil
 end
 
 function Pacifist:create(entity, uri)
-   self._sv._entity = entity
-   self._sv._uri = uri
+	self._sv._entity = entity
+	self._sv._uri = uri
 end
 
 function Pacifist:post_activate()
-   local json = radiant.resources.load_json(self._sv._uri)
-   local customization_component = self._sv._entity:get_component('stonehearth:customization')
-   customization_component:change_customization("eyebrows", "flower")
+	local json = radiant.resources.load_json(self._sv._uri)
+	local customization_component = self._sv._entity:get_component('stonehearth:customization')
+	customization_component:change_customization("eyebrows", "flower")
 
-    local population = stonehearth.population:get_population(self._sv._entity:get_player_id())
-    self.pop_listener = radiant.events.listen_once(population, 'stonehearth:population:citizen_count_changed', function()
-      if not self._sv._entity:get_component('stonehearth:unit_info')._sv._made_pacifist then
-         local all_jobs = stonehearth.player:get_jobs(self._sv._entity:get_player_id())
-         local allowed_jobs = {}
-         for job_uri, _ in pairs(all_jobs) do
-            allowed_jobs[job_uri] =  not stonehearth.job:get_job_info(self._sv._entity:get_player_id(), job_uri):is_combat_job()
-         end
-         self._sv._entity:get_component('stonehearth:job')._sv.allowed_jobs = allowed_jobs
-         self._sv._entity:get_component('stonehearth:unit_info')._sv._made_pacifist = true
+	local population = stonehearth.population:get_population(self._sv._entity:get_player_id())
+	self.pop_listener = radiant.events.listen_once(population, 'stonehearth:population:citizen_count_changed', function()
+		if not self._sv._entity:get_component('stonehearth:unit_info')._sv._made_pacifist then
 
-         -- PROMOTE THE HEARTHLING TO IT'S OWN JOB AGAIN, This is a hack to fix a rendering bug in the promotion tree
-        local options = {}
-        options.dont_drop_talisman = true
-        options.skip_visual_effects = true
-        local current_job_uri = self._sv._entity:get_component('stonehearth:job')._sv.job_uri
-        self._sv._entity:get_component('stonehearth:job'):promote_to(current_job_uri, options)
+			local job_comp = self._sv._entity:get_component('stonehearth:job')
+			local allowed = job_comp:get_allowed_jobs()
+			for job_uri, _ in pairs(allowed) do
+				if stonehearth.job:get_job_info(self._sv._entity:get_player_id(), job_uri):is_combat_job() then
+					allowed[job_uri] = false
+				end
+			end
+			job_comp:set_allowed_jobs(allowed)
+			self._sv._entity:get_component('stonehearth:unit_info')._sv._made_pacifist = true
 
-      end
-   end)
-      
+		end
+	end)
+
 end
 
 function Pacifist:destroy()
-   local customization_component = self._sv._entity:get_component('stonehearth:customization')
-   customization_component:change_customization("eyebrows", nil)
-    self.pop_listener:destroy()
+	local customization_component = self._sv._entity:get_component('stonehearth:customization')
+	customization_component:change_customization("eyebrows", nil)
+	self.pop_listener:destroy()
 end
 
 if GameCreationService and not GameCreationService.kmnky_traits_injection then
-   local old_randomize_citizen = GameCreationService._randomize_citizen
+	local old_randomize_citizen = GameCreationService._randomize_citizen
 
-   function GameCreationService:_randomize_citizen(citizen, pop, gender, locked_options)
-      old_randomize_citizen(self, citizen, pop, gender, locked_options)
-      pop:regenerate_stats(citizen, { embarking = true })
-   end
-   GameCreationService.kmnky_traits_injection = true
+	function GameCreationService:_randomize_citizen(citizen, pop, gender, locked_options)
+		old_randomize_citizen(self, citizen, pop, gender, locked_options)
+		pop:regenerate_stats(citizen, { embarking = true })
+	end
+	GameCreationService.kmnky_traits_injection = true
 end
 
 return Pacifist


### PR DESCRIPTION
Traits were setting jobs to true/false for the entire tree instead of just the ones that should be affected by the trait
For example, barbarian was trying to set knight job to false, but before doing that it set all others to true. And pacifist was setting all military to off, but all non combat to true.
This change makes traits change only the related jobs, so the job tree keeps its original/custom structure, For example, orcs have only worker and footman as jobs, they should not have the other jobs set to true